### PR TITLE
Em runtime2

### DIFF
--- a/scmail_tests.py
+++ b/scmail_tests.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-#from unit_tests.unit_tests_MLSolver import *
+from unit_tests.unit_tests_MLSolver import *
 #from unit_tests.unit_tests_Simulator import *
 #from unit_tests.unit_tests_SpaLinSolver import *
 from scmail_unit_tests.unit_tests_TopoSearch import *


### PR DESCRIPTION
[x] removing stale timeit code
[x] adding runtime breakdown for EM in verbose setting
[x] adding handling for noSilence case, with convex computation of branch lengths
[x] adding back the MLSolver tests for the scmail_tests lightweight suite, takes negligible additional time
